### PR TITLE
chore: Bump reqwest_middleware to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ categories = ["web-programming::http-client"]
 
 [dependencies]
 async-trait = "0.1"
-reqwest = { version = "0.11", default-features = false }
-reqwest-middleware = "0.2"
-task-local-extensions = "0.1"
+http = "1.1.0"
+reqwest = { version = "0.12.0", default-features = false }
+reqwest-middleware = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@
 //! }
 //! ```
 use async_trait::async_trait;
+use http::Extensions;
 use reqwest::{Request, Response};
 use reqwest_middleware::{Next, Result};
-use task_local_extensions::Extensions;
 
 /// Request rate limiter.
 #[async_trait]
@@ -52,7 +52,7 @@ impl<R: RateLimiter> reqwest_middleware::Middleware for Middleware<R> {
     async fn handle(
         &self,
         req: Request,
-        extensions: &mut Extensions,
+        extensions: &'_ mut Extensions,
         next: Next<'_>,
     ) -> Result<Response> {
         self.rate_limiter.acquire_permit().await;


### PR DESCRIPTION
The latest version has breaking changes to the `Middleware` trait.